### PR TITLE
fix(canada): enrich status payload with vehicle location

### DIFF
--- a/Sources/BetterBlueKit/API/HyundaiAPI/HyundaiCanada+Parsing.swift
+++ b/Sources/BetterBlueKit/API/HyundaiAPI/HyundaiCanada+Parsing.swift
@@ -144,6 +144,19 @@ extension HyundaiCanadaAPIClient {
         return authCode
     }
 
+    func parseCanadaLocationResponse(_ data: Data) throws -> VehicleStatus.Location {
+        let json = try parseCanadaResponse(data, context: "location")
+        guard let result = json["result"] as? [String: Any],
+              let coord = result["coord"] as? [String: Any] else {
+            throw APIError.logError("Invalid Canada location response", apiName: apiName)
+        }
+
+        return VehicleStatus.Location(
+            latitude: extractNumber(from: coord["lat"]) ?? 0,
+            longitude: extractNumber(from: coord["lon"]) ?? 0
+        )
+    }
+
     // MARK: - Status Parsing Helpers
 
     private func detectElectricVehicle(from vehicleData: [String: Any]) -> Bool {

--- a/Sources/BetterBlueKit/API/HyundaiAPI/HyundaiCanadaAPIClient.swift
+++ b/Sources/BetterBlueKit/API/HyundaiAPI/HyundaiCanadaAPIClient.swift
@@ -97,11 +97,12 @@ public final class HyundaiCanadaAPIClient: APIClientBase, APIClientProtocol {
             requestType: .fetchVehicleStatus
         )
 
-        let finalData = cached ? primaryData : try await fetchRealtimeStatusData(
+        let statusData = cached ? primaryData : try await fetchRealtimeStatusData(
             primaryData: primaryData,
             vehicle: vehicle,
             authToken: authToken
         )
+        let finalData = await injectLocationCoordinates(into: statusData, vehicle: vehicle, authToken: authToken)
 
         do {
             return try parseCanadaVehicleStatusResponse(finalData, for: vehicle)
@@ -131,29 +132,29 @@ public final class HyundaiCanadaAPIClient: APIClientBase, APIClientProtocol {
             BBLogger.debug(.api, "HyundaiCanada: failed fetching sltvhcl: \(error)")
         }
 
-        // Fetch GPS coordinates from PIN-protected endpoint and inject into payload
-        finalData = await injectGPSCoordinates(into: finalData, vehicle: vehicle, authToken: authToken)
         return finalData
     }
 
-    private func injectGPSCoordinates(into data: Data, vehicle: Vehicle, authToken: AuthToken) async -> Data {
+    private func injectLocationCoordinates(into data: Data, vehicle: Vehicle, authToken: AuthToken) async -> Data {
         do {
             let pAuth = try await fetchCommandAuthCode(authToken: authToken)
-            let (_, fmeJson, _) = try await performJSONRequest(
-                url: "\(apiBaseURL)/evc/fme",
+            let (locationData, _, _) = try await performJSONRequest(
+                url: "\(apiBaseURL)/fndmcr",
                 method: .POST,
                 headers: authorizedHeaders(authToken: authToken, vehicleId: vehicle.regId, pAuth: pAuth),
-                body: ["vehicleId": vehicle.regId],
+                body: ["pin": pin],
                 requestType: .fetchVehicleStatus
             )
+            let location = try parseCanadaLocationResponse(locationData)
 
-            guard let fmeResult = fmeJson["result"] as? [String: Any],
-                  let gpsDetail = fmeResult["gpsDetail"] as? [String: Any],
-                  let coord = gpsDetail["coord"] as? [String: Any],
-                  var finalJson = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            guard var finalJson = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 return data
             }
 
+            let coord: [String: Any] = [
+                "lat": location.latitude,
+                "lon": location.longitude
+            ]
             var result = finalJson["result"] as? [String: Any] ?? [:]
             var status = result["status"] as? [String: Any]
                 ?? result["vehicleStatus"] as? [String: Any] ?? [:]
@@ -163,7 +164,7 @@ public final class HyundaiCanadaAPIClient: APIClientBase, APIClientProtocol {
             finalJson["result"] = result
             return try JSONSerialization.data(withJSONObject: finalJson)
         } catch {
-            BBLogger.debug(.api, "HyundaiCanada: failed injecting GPS: \(error)")
+            BBLogger.debug(.api, "HyundaiCanada: failed injecting location: \(error)")
             return data
         }
     }

--- a/Tests/BetterBlueKitTests/RegionSpecificTests.swift
+++ b/Tests/BetterBlueKitTests/RegionSpecificTests.swift
@@ -282,6 +282,80 @@ struct RegionSpecificTests {
         #expect(statusResult.washerFluidLow == true)
     }
 
+    @MainActor @Test("Canada location response parsing reads fndmcr coordinates")
+    func testCanadaLocationResponseParsing() throws {
+        let json: [String: Any] = [
+            "responseHeader": ["responseCode": 0],
+            "result": [
+                "coord": [
+                    "lat": 43.6532,
+                    "lon": -79.3832
+                ]
+            ]
+        ]
+
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let config = APIClientConfiguration(
+            region: .canada,
+            brand: .hyundai,
+            username: "",
+            password: "",
+            pin: "",
+            accountId: UUID()
+        )
+        let client = HyundaiCanadaAPIClient(configuration: config)
+
+        let location = try client.parseCanadaLocationResponse(data)
+        #expect(location.latitude == 43.6532)
+        #expect(location.longitude == -79.3832)
+    }
+
+    @MainActor @Test("Canada status parsing uses injected vehicle location coordinates")
+    func testCanadaStatusParsingInjectedLocation() throws {
+        let status: [String: Any] = [
+            "doorLock": true,
+            "airTemp": ["value": "22", "unit": 0],
+            "defrost": false,
+            "airCtrlOn": false,
+            "steerWheelHeat": 0,
+            "lastStatusDate": "20260221195224",
+            "vehicleLocation": [
+                "coord": [
+                    "lat": 43.6532,
+                    "lon": -79.3832
+                ]
+            ]
+        ]
+        let json: [String: Any] = [
+            "responseHeader": ["responseCode": 0],
+            "result": ["status": status]
+        ]
+
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let config = APIClientConfiguration(
+            region: .canada,
+            brand: .hyundai,
+            username: "",
+            password: "",
+            pin: "",
+            accountId: UUID()
+        )
+        let client = HyundaiCanadaAPIClient(configuration: config)
+        let vehicle = Vehicle(
+            vin: "TESTVIN",
+            regId: "REG",
+            model: "MODEL",
+            accountId: UUID(),
+            isElectric: false,
+            generation: 1,
+            odometer: Distance(length: 0, units: .kilometers)
+        )
+
+        let statusResult = try client.parseCanadaVehicleStatusResponse(data, for: vehicle)
+        #expect(statusResult.location.latitude == 43.6532)
+        #expect(statusResult.location.longitude == -79.3832)
+    }
+
     // MARK: - API Client Creation Tests
 
     @Test("API client creation for supported regions")


### PR DESCRIPTION
**Summary**

  Align the Canada API client with the existing US status parsing flow by
  enriching the Canada status payload with vehicle location before parsing
  VehicleStatus.

  Previously, the Canada client had a separate location-fetch path that
  did not fully match the library’s primary status-driven flow. This
  change keeps the parser behavior consistent by ensuring location is
  injected into the status payload in the same shape the parser already
  expects.

  **What Changed**

  - Updated the Canada client to fetch location from the Canada fndmcr
    endpoint.
  - Injected the returned coordinates into the status payload as
    vehicleLocation.coord / coord before parsing.
  - Kept the existing VehicleStatus parsing flow intact so location
    continues to be derived from the status payload.
  - Added parsing support for the Canada location response shape.
  - Added tests covering:
      - parsing the Canada location response
      - parsing injected location data from the Canada status payload
  
  Fixes #16 