### PR TITLE
Hyundai EU: lazy-generate Stamp header per request

### DIFF
--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Headers.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Headers.swift
@@ -28,7 +28,9 @@ extension HyundaiEuropeAPIClient {
             "Host": apiHost,
             "Connection": "Keep-Alive",
             "Accept-Encoding": "gzip",
-            "Stamp": stamp
+            // Fresh HMAC per request — Stamp is an `<appId>:<ISO8601>` signature
+            // and the server appears to validate the timestamp window.
+            "Stamp": generateStamp()
         ]
     }
 

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient.swift
@@ -20,7 +20,6 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
     static let clientSecret = "KUy49XxPzLpLuoK0xhBC77W6VXhmtQR9iQhmIFjjoY4IpxsV"
     static let appId = "014d2225-8495-4735-812d-2616334fd15d"
     static let authCfb = "RFtoRq/vDXJmRndoZaZQyfOot7OrIqGVFj96iY2WL3yyH5Z/pUvlUhqmCxD2t+D65SQ="
-    var stamp = ""
     var commandToken: String = ""
     var commandTokenExpiration: Date = Date()
 
@@ -152,7 +151,7 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
     }
 
     public override func registerDevice() async throws -> String? {
-        stamp = generateStamp()
+        let stamp = generateStamp()
         let body = [
             "pushRegId": stamp,
             "pushType": "GCM",


### PR DESCRIPTION
## Summary

The `stamp` property on `HyundaiEuropeAPIClient` was a cached in-memory `String` only initialized inside `registerDevice()`. Any callsite that constructs a fresh `HyundaiEuropeAPIClient` and skips straight to `login()` or `fetchVehicles()` ends up sending `Stamp: \"\"` over the wire.

I caught this while debugging app-side issues (BetterBlue) using a recent `KiaEuropeAPIClient` build — the captured HTTP log showed `\"Stamp\": \"\"` on a successful `fetchVehicles` request because BetterBlue creates a fresh API client per request and never re-calls `registerDevice`. Server happened to accept it for that endpoint, but the same pattern would break device-id-bound calls.

## The fix

- Drops the `var stamp = \"\"` instance property
- `registerDevice` now uses a local `let stamp = generateStamp()` (so the body and header still agree within that one call)
- `authorizedHeaders` calls `generateStamp()` directly, so every request gets a fresh HMAC

The Stamp header is an HMAC of `<appId>:<ISO8601 timestamp>` keyed by the `authCfb` seed (see `generateStamp()` in `+Headers.swift`). The server appears to validate the timestamp window, so caching a stamp indefinitely is also wrong for long-lived clients — fresh per request matches what [`hyundai_kia_connect_api`](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/blob/master/hyundai_kia_connect_api/ApiImplType1.py) does in `_get_authenticated_headers`.

## Notes

- Same pattern exists in `KiaEuropeAPIClient` (PR #29). Happy to follow up with an equivalent fix there once #29 is merged, so this PR stays small and reviewable.
- `commandHeaders` extends `authorizedHeaders`, so it picks up the lazy stamp automatically.

## Test plan

- [x] `swift build` clean
- [x] `swift test` clean (261 tests passing)

Could not exercise the change end-to-end on a Hyundai EU account (I drive a Kia EV9), but the change is a pure refactor of how an existing header value is computed — same algorithm, just called per-request instead of once.