### PR TITLE
Kia EU: lazy-generate Stamp header per request

### DIFF
--- a/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient+Headers.swift
+++ b/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient+Headers.swift
@@ -29,7 +29,9 @@ extension KiaEuropeAPIClient {
             "Host": apiHost,
             "Connection": "Keep-Alive",
             "Accept-Encoding": "gzip",
-            "Stamp": stamp
+            // Fresh HMAC per request — Stamp is an `<appId>:<ISO8601>` signature
+            // and the server appears to validate the timestamp window.
+            "Stamp": generateStamp()
         ]
     }
 

--- a/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient.swift
+++ b/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient.swift
@@ -33,7 +33,6 @@ public final class KiaEuropeAPIClient: APIClientBase, APIClientProtocol {
         "AppleWebKit/535.19 (KHTML, like Gecko) " +
         "Chrome/18.0.1025.166 Mobile Safari/535.19_CCS_APP_AOS"
 
-    var stamp = ""
     var commandToken: String = ""
     var commandTokenExpiration: Date = Date()
 
@@ -201,7 +200,7 @@ public final class KiaEuropeAPIClient: APIClientBase, APIClientProtocol {
     // MARK: - Device registration
 
     public override func registerDevice() async throws -> String? {
-        stamp = generateStamp()
+        let stamp = generateStamp()
         let body = [
             "pushRegId": stamp,
             "pushType": Self.pushType,


### PR DESCRIPTION
## Summary

Same fix as #30, applied to `KiaEuropeAPIClient`. The new Kia EU client (merged in #29) inherited the same cached-`stamp` pattern that Hyundai EU had — so any host app that constructs a fresh `APIClient` per session and skips `registerDevice()` ends up shipping `Stamp: ""`.

Three-line patch:
- drop the `var stamp = ""` instance property
- `registerDevice()` uses a local `let stamp`
- `authorizedHeaders` calls `generateStamp()` directly so each request ships a fresh HMAC

Matches `ApiImplType1` in `hyundai_kia_connect_api` and is consistent with #30.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 273/273 passing
- [ ] Live-tested against my Kia EV9 in #29; this only changes when the Stamp is computed, not its contents, so behavior is unchanged for the `bbcli` flow that already re-registers each session