### PR TITLE
Fix Hyundai Europe commands on legacy (non-CCS2) vehicles

### DIFF
--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Commands.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Commands.swift
@@ -17,10 +17,10 @@ extension HyundaiEuropeAPIClient {
         switch command {
         case .lock:
             return ccs2 ? ("ccs2/control/door", ["command": "close"])
-            : ("/control/door", ["action": "close", "deviceId": deviceId])
+            : ("control/door", ["action": "close", "deviceId": deviceId])
         case .unlock:
             return ccs2 ? ("ccs2/control/door", ["command": "open"])
-            : ("/control/door", ["action": "open", "deviceId": deviceId])
+            : ("control/door", ["action": "open", "deviceId": deviceId])
         case .startClimate(let options):
             // EU CCS2 vehicles only accept temperatures on the
             // 0.5°C grid (15.0–30.0). The car silently no-ops when

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient.swift
@@ -199,30 +199,30 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
             return
         }
 
-        let body = [
-            "deviceId": configuration.deviceId,
+        let body: [String: Any] = [
+            "deviceId": configuration.deviceId ?? "",
             "pin": pin
         ]
 
-        let headers = authorizedHeaders(authToken: authToken)
-
-        let bodyData = try? JSONSerialization.data(
-            withJSONObject: body, options: []
+        // Route through performJSONRequest so the PIN/control-token
+        // request is captured in the HTTP logs and its status is
+        // validated. Previously this used a raw URLSession call, so a
+        // failure here was invisible to diagnostics and surfaced only
+        // as a generic "Failed to get command token".
+        let (_, json, _) = try await performJSONRequest(
+            url: "\(baseURL)/api/v1/user/pin?token=",
+            method: .PUT,
+            headers: authorizedHeaders(authToken: authToken),
+            body: body,
+            requestType: .sendCommand
         )
 
-        var request = URLRequest(url: URL(string: "\(baseURL)/api/v1/user/pin?token=")!)
-        request.httpMethod = "PUT"
-        request.httpBody = bodyData
-
-        for (key, value) in headers {
-            request.setValue(value, forHTTPHeaderField: key)
-        }
-
-        let (data, _) = try await urlSession.data(for: request)
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let token = json["controlToken"] as? String,
+        guard let token = json["controlToken"] as? String,
               let expires = json["expiresTime"] as? Int else {
-            throw APIError(message: "Failed to get command token", apiName: apiName)
+            throw APIError(
+                message: "PIN verification failed — check that the account PIN is correct.",
+                apiName: apiName
+            )
         }
 
         commandToken = token
@@ -277,13 +277,24 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
     // MARK: - Commands
 
     public func sendCommand(for vehicle: Vehicle, command: VehicleCommand, authToken: AuthToken) async throws {
-        let (path, body) = commandPathAndBody(for: command)
         let ccs2 = vehicle.marketOptions?.ccs2Supported ?? false
+        let (path, body) = commandPathAndBody(for: command, ccs2: ccs2)
         let url =
             "\(baseURL)/api/\(ccs2 ? "v2" : "v1")"
             + "/spa/vehicles/\(vehicle.regId)/\(path)"
-        try await setCommandToken(authToken: authToken)
-        let header = commandHeaders(authToken: authToken, ccs2: ccs2)
+
+        // CCS2 (Gen5W) cars authenticate commands with a PIN-derived
+        // control token; legacy cars use the normal access token and
+        // have no PIN step at all. Fetching a control token for a
+        // legacy car is what produced the "Failed to get command token"
+        // error — the PIN endpoint isn't part of the legacy flow.
+        let header: [String: String]
+        if ccs2 {
+            try await setCommandToken(authToken: authToken)
+            header = commandHeaders(authToken: authToken, ccs2: ccs2)
+        } else {
+            header = authorizedHeaders(authToken: authToken, ccs2: ccs2)
+        }
 
         _ = try await performJSONRequest(
             url: url,


### PR DESCRIPTION
## Problem

Sending commands (lock/unlock/charge) to **legacy, non-CCS2** Hyundai Europe vehicles (e.g. a gen2 Bayon) fails with **"Failed to get command token"** / `Lock … failed`.

## Root cause

EU commands authenticate differently depending on vehicle generation, per the authoritative `hyundai_kia_connect_api` (`ApiImplType1.lock_action` / `start_charge` / …):

| | Legacy (non-CCS2) | CCS2 (Gen5W) |
|---|---|---|
| URL | `POST /api/v1/spa/…/control/door` | `POST /api/v2/spa/…/ccs2/control/door` |
| Body | `{action, deviceId}` | `{command}` |
| Auth | normal **access token** | **PIN-derived control token** |

`sendCommand` called `setCommandToken()` (the `PUT /api/v1/user/pin` step) **unconditionally**, but legacy cars have no PIN/control-token step — so that fetch is what threw "Failed to get command token". It also built a malformed path because `commandPathAndBody()` defaulted to `ccs2: true` while the URL was built as `v1`.

This is the *"wrong token usage on legacy command path"* anomaly noted in schmidtwmark/BetterBlueKit#8.

## Changes

- **`sendCommand`**: branch on `ccs2` — control token + `commandHeaders` for CCS2; plain `authorizedHeaders` (no PIN) for legacy. Pass the real `ccs2` flag into `commandPathAndBody`.
- **`commandPathAndBody`**: drop the stray leading slash in the legacy door path (`"/control/door"` → `"control/door"`) that produced a double slash.
- **`setCommandToken`**: route through `performJSONRequest` so the PIN request is captured in HTTP logs and status-validated (previously a raw `URLSession` call, invisible to diagnostics), with a clearer PIN-failure message.

## Testing

- `swift build` passes.
- Verified the legacy lock/unlock/charge paths, bodies, and header choice against `hyundai_kia_connect_api` `ApiImplType1`.
- Live verification needs a real EU vehicle: lock should now POST to `/api/v1/spa/…/control/door` and return 200.

## Known remaining gap (not addressed here)

`startClimate` still always returns the `ccs2/control/temperature` path regardless of the flag; legacy climate-start needs a dedicated `control/temperature` branch with the reference's hvac payload.

Refs schmidtwmark/BetterBlueKit#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)