### PR TITLE
Make Hyundai Europe location parsing robust

### DIFF
--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Parsing.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Parsing.swift
@@ -261,17 +261,33 @@ extension HyundaiEuropeAPIClient {
         let locationTimeZone = pathMap.apiProfile == .legacy ? TimeZone(identifier: "Europe/Berlin") : TimeZone.gmt
         let locationDate = BluelinkDateParser.parse(locationDateString, timeZone: locationTimeZone)
 
-        // location date is older than parking endpoint date -> use parking location
-        if let parkDate, let locationDate, locationDate.compare(parkDate).rawValue <= 0 {
-            return VehicleStatus.Location(
-                latitude: getDoubleFromJson(from: park, key: pathMap[.parkLat]),
-                longitude: getDoubleFromJson(from: park, key: pathMap[.parkLon])
-            )
-        }
-        return VehicleStatus.Location(
+        // Two candidate sources: the /location/park endpoint and the
+        // location embedded in the status response. Either can be empty —
+        // park returns no coordinates when the car has no recent park
+        // event, and the status-embedded location is often stale/missing.
+        let parkLocation = VehicleStatus.Location(
+            latitude: getDoubleFromJson(from: park, key: pathMap[.parkLat]),
+            longitude: getDoubleFromJson(from: park, key: pathMap[.parkLon])
+        )
+        let statusLocation = VehicleStatus.Location(
             latitude: getDoubleFromJson(from: vehicleState, key: pathMap[.locationLat]),
             longitude: getDoubleFromJson(from: vehicleState, key: pathMap[.locationLon])
         )
+
+        // Prefer the park endpoint when it has coordinates and is at least
+        // as recent as the (often stale) status location. Fall back to
+        // whichever source actually carries coordinates so a missing park
+        // event no longer drops the location entirely.
+        let parkIsNewer = (parkDate != nil && locationDate != nil)
+            ? locationDate!.compare(parkDate!).rawValue <= 0
+            : parkLocation.hasCoordinates
+        if parkIsNewer, parkLocation.hasCoordinates {
+            return parkLocation
+        }
+        if statusLocation.hasCoordinates {
+            return statusLocation
+        }
+        return parkLocation.hasCoordinates ? parkLocation : statusLocation
     }
 
     private func parseTirePressure(from vehicleState: [String: Any], pathMap: HyEuResponseKeyPathMap)
@@ -314,7 +330,7 @@ extension HyundaiEuropeAPIClient {
         switch getAnyFromJson(from: data, key: keyString!) {
         case let value as Double: return value
         case let value as Int: return Double(value)
-        case let value as String: return Double(value)!
+        case let value as String: return Double(value) ?? 0
         default: return 0
         }
     }

--- a/Sources/BetterBlueKit/Models/VehicleStatus.swift
+++ b/Sources/BetterBlueKit/Models/VehicleStatus.swift
@@ -85,6 +85,11 @@ public struct VehicleStatus: Codable, Hashable, Sendable {
         }
 
         public var debug: String { "\(latitude)°, \(longitude)°" }
+
+        /// True when the location carries real coordinates. The APIs use
+        /// (0, 0) — null island — as their "no fix" sentinel, so treat that
+        /// as absent.
+        public var hasCoordinates: Bool { latitude != 0 || longitude != 0 }
     }
 
     public var location: Location


### PR DESCRIPTION
## Problem

On Hyundai Europe vehicles, status syncs return everything (battery, lock, climate, odometer, tyres) **except the car location**, which shows as missing.

## Root cause

`parseLocation` chose between the two location sources purely by timestamp:

- `…/location/park` (a cached park snapshot)
- the location embedded in the status response (`vehicleLocation`)

It returned the `/location/park` branch whenever its date was newer — **even when that endpoint returned no coordinates** (the car has had no recent park event). Combined with a status body that carries no embedded `vehicleLocation`, the location collapsed to `(0, 0)` and disappeared. There was no fallback to the other source.

For reference, `hyundai_kia_connect_api` only uses `/location/park` *when it actually contains coordinates* (`if … get_child_value(location, "coord.lat")`) and otherwise keeps the live location.

## Changes

- **`parseLocation`** reads both candidate sources and falls back to whichever actually carries coordinates, only preferring `/location/park` when it is non-empty **and** at least as recent as the status location.
- **`VehicleStatus.Location.hasCoordinates`** — new helper treating `(0, 0)` (null island) as "no fix".
- **`getDoubleFromJson`** — fixed a force-unwrap (`Double(value)!`) that would crash the entire status parse on any non-numeric coordinate string.

## Testing

- `swift build` passes.
- Legacy/CCS2 coordinate and date key paths verified against `hyundai_kia_connect_api`.

## Note

This addresses the common "no recent park event" case where one source is empty. If a vehicle returns coordinates from neither source, a dedicated `GET …/location` call (as the reference makes) would be the follow-up — happy to add it if logs show that shape.