### PR TITLE
Kia EU: fix commands on legacy (non-CCS2) vehicles

### DIFF
--- a/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient+Commands.swift
+++ b/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient+Commands.swift
@@ -17,11 +17,11 @@ extension KiaEuropeAPIClient {
         case .lock:
             return ccs2
                 ? ("ccs2/control/door", ["command": "close"])
-                : ("/control/door", ["action": "close", "deviceId": deviceId])
+                : ("control/door", ["action": "close", "deviceId": deviceId])
         case .unlock:
             return ccs2
                 ? ("ccs2/control/door", ["command": "open"])
-                : ("/control/door", ["action": "open", "deviceId": deviceId])
+                : ("control/door", ["action": "open", "deviceId": deviceId])
         case .startClimate(let options):
             return ("ccs2/control/temperature", startClimateBody(options: options))
         case .stopClimate:

--- a/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient.swift
+++ b/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient.swift
@@ -193,12 +193,17 @@ public final class KiaEuropeAPIClient: APIClientBase, APIClientProtocol {
     // MARK: - Commands
 
     public func sendCommand(for vehicle: Vehicle, command: VehicleCommand, authToken: AuthToken) async throws {
-        let (path, body) = commandPathAndBody(for: command)
         let ccs2 = vehicle.marketOptions?.ccs2Supported ?? false
+        let (path, body) = commandPathAndBody(for: command, ccs2: ccs2)
         let url = "\(baseURL)/api/\(ccs2 ? "v2" : "v1")"
             + "/spa/vehicles/\(vehicle.regId)/\(path)"
-        try await setCommandToken(authToken: authToken)
-        let headers = commandHeaders(authToken: authToken, ccs2: ccs2)
+        let headers: [String: String]
+        if ccs2 {
+            try await setCommandToken(authToken: authToken)
+            headers = commandHeaders(authToken: authToken, ccs2: ccs2)
+        } else {
+            headers = authorizedHeaders(authToken: authToken, ccs2: ccs2)
+        }
 
         _ = try await performJSONRequest(
             url: url,


### PR DESCRIPTION
Mirrors @Nachtlatscher's #32 for Hyundai Europe — the same three bugs exist in the Kia Europe client and were flagged on the #29 thread.

## Fixes

1. **Leading slash on door commands** (`KiaEuropeAPIClient+Commands.swift`). `lock`/`unlock` returned `"/control/door"` while every other legacy case returned `"control/..."`, so the URL builder produced a double slash (`…/spa/vehicles/<id>//control/door`).

2. **Control-token used on legacy endpoints** (`KiaEuropeAPIClient.swift`). `sendCommand` unconditionally fetched a PIN-derived control token and used `commandHeaders` (`Authorization: Bearer <controlToken>`). Legacy v1 endpoints reject this with `400 "Authorization field missing"` — they expect the regular access token. Gate the control-token flow on `ccs2`; legacy uses `authorizedHeaders(authToken:ccs2:)` directly.

3. **`commandPathAndBody` always took the CCS2 branch.** The call site passed no `ccs2:` argument, so the default `ccs2: true` always selected the CCS2 path/body shape — even for legacy vehicles whose URL was being built as v1. Pass `ccs2: ccs2` explicitly.

## Validation

Live-tested against my CCS2 Kia EV9 by hard-coding `ccs2 = false` locally to force the legacy branch:

- **Before fix:** \`POST /api/v1/spa/vehicles/<id>//control/door\` → \`400 "Authorization field missing"\` (both bugs visible — double slash + control-token rejected).
- **After fix:** \`POST /api/v1/spa/vehicles/<id>/control/door\` with \`{"action": "close/open", "deviceId": "..."}\` → \`200 resCode "0000"\` for both lock and unlock. **Doors physically locked/unlocked**, which incidentally confirms that the Bluelink backend routes both legacy v1 and CCS2 endpoints to the same vehicle-command handler.

Normal CCS2 path on my EV9 unchanged (still works, 286/286 tests pass).

A true CCS1 vehicle owner would be the ideal validator, but the wire-level fix is confirmed by the symmetry with #32 and the Python reference (\`ApiImplType1\`).

🤖 Drafted with assistance from Claude Code (Anthropic).