### PR TITLE
Add Hyundai Europe auth, command routing, and parsing support

### DIFF
--- a/Sources/BBCLI/main.swift
+++ b/Sources/BBCLI/main.swift
@@ -149,7 +149,7 @@ func printUsage() {
       -h, --help                Show this help message
 
     Parse Mode:
-      bbcli parse -b <brand> -r <region> -t <type> [--vin <vin>] [--electric] <json>
+      bbcli parse -b <brand> -r <region> -t <type> [--vin <vin>] [--electric] [--ccs2|--legacy] <json>
 
       Parses a raw API response JSON and outputs the parsed BetterBlueKit struct.
 
@@ -157,6 +157,8 @@ func printUsage() {
       --vin <vin>               VIN for vehicleStatus parsing (default: TESTVIN0000000000)
       --electric                Mark vehicle as electric for parsing (auto-detected from
                                 evStatus field in vehicles response if not specified)
+      --ccs2                    Parse Hyundai/Kia Europe vehicleStatus as CCS2/CCNC
+      --legacy                  Parse Hyundai/Kia Europe vehicleStatus as Gen5W/non-CCS2
       <json>                    JSON string or path to a JSON file (last argument)
 
       If the JSON contains a top-level "responseBody" key, it will be automatically
@@ -553,6 +555,7 @@ struct ParseOptions {
     var parseType: ParseType?
     var vin: String = "TESTVIN0000000000"
     var fuelType: FuelType?  // nil = auto-detect
+    var ccs2Override: Bool?
     var jsonInput: String?
 }
 
@@ -606,6 +609,10 @@ func parseParseArguments() -> ParseOptions {
             }
         case "--electric":
             options.fuelType = .electric
+        case "--ccs2":
+            options.ccs2Override = true
+        case "--legacy":
+            options.ccs2Override = false
         case "-h", "--help":
             printUsage()
             exit(0)
@@ -655,6 +662,35 @@ func unwrapResponseBody(_ data: Data) -> Data {
         return unwrapped
     }
     return data
+}
+
+func inferEuropeCCS2Status(from data: Data, brand: Brand, region: Region) -> Bool {
+    guard region == .europe,
+          brand == .hyundai || brand == .kia,
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let resMsg = json["resMsg"] as? [String: Any] else {
+        return false
+    }
+
+    if resMsg["state"] != nil {
+        return true
+    }
+    return false
+}
+
+func parseModeMarketOptions(brand: Brand, region: Region, ccs2: Bool) -> VehicleMarketOptions {
+    guard region == .europe else {
+        return .generic
+    }
+
+    switch brand {
+    case .hyundai:
+        return .hyundaiEurope(ccs2Supported: ccs2)
+    case .kia:
+        return .kiaEurope(ccs2Supported: ccs2)
+    case .fake:
+        return .generic
+    }
 }
 
 func encodePrettyJSON<T: Encodable>(_ value: T) -> String {
@@ -708,6 +744,11 @@ func runParseMode() async -> Int32 {
 
         case .vehicleStatus:
             let fuelType = options.fuelType ?? .gas
+            let ccs2 = options.ccs2Override ?? inferEuropeCCS2Status(
+                from: data,
+                brand: options.brand,
+                region: options.region
+            )
             let vehicle = Vehicle(
                 vin: options.vin,
                 regId: "parse-mode",
@@ -715,7 +756,12 @@ func runParseMode() async -> Int32 {
                 accountId: UUID(),
                 fuelType: fuelType,
                 generation: 2,
-                odometer: Distance(length: 0, units: .miles)
+                odometer: Distance(length: 0, units: .miles),
+                marketOptions: parseModeMarketOptions(
+                    brand: options.brand,
+                    region: options.region,
+                    ccs2: ccs2
+                )
             )
             let status = try parseVehicleStatus(client: client, data: data, vehicle: vehicle)
             printSuccess("Parsed vehicle status")

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Auth.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Auth.swift
@@ -1,0 +1,174 @@
+//
+//  HyundaiEuropeAPIClient+Auth.swift
+//  BetterBlueKit
+//
+//  IDPConnect signin and token helpers for Hyundai Europe.
+//
+
+import Foundation
+
+extension HyundaiEuropeAPIClient {
+
+    /// IDPConnect headless signin: authorize -> certs -> encrypted-signin -> redirect with ?code=.
+    func signin() async throws -> String {
+        let state = UUID().uuidString
+        try await fetchAuthorizeCookies(state: state)
+        let jwk = try await fetchSigninJWK()
+        let encryptedHex = try rsaEncryptPKCS1(password: password, jwkN: jwk.modulus, jwkE: jwk.exponent)
+        let signinResp = try await submitSignin(encryptedHex: encryptedHex, kid: jwk.kid, state: state)
+        return try parseSigninCode(from: signinResp, expectedState: state)
+    }
+
+    /// Step 1: GET authorize to establish the IDPConnect session cookies used by signin.
+    private func fetchAuthorizeCookies(state: String) async throws {
+        let query = Self.formEncode([
+            ("response_type", "code"),
+            ("client_id", Self.clientId),
+            ("redirect_uri", oauthRedirectURI),
+            ("lang", "en"),
+            ("state", state),
+            ("country", "de")
+        ])
+        var request = URLRequest(url: URL(string: "\(authBaseURL)/auth/api/v2/user/oauth2/authorize?\(query)")!)
+        request.setValue(Self.mobileUserAgent, forHTTPHeaderField: "User-Agent")
+        _ = try await urlSession.data(for: request)
+    }
+
+    /// RSA public key returned by `/auth/api/v1/accounts/certs`.
+    private struct HyundaiEuropeJWK {
+        let modulus: String
+        let exponent: String
+        let kid: String
+    }
+
+    /// Step 2: GET certs and pull the JWK fields needed for password encryption.
+    private func fetchSigninJWK() async throws -> HyundaiEuropeJWK {
+        var request = URLRequest(url: URL(string: "\(authBaseURL)/auth/api/v1/accounts/certs")!)
+        request.setValue(Self.mobileUserAgent, forHTTPHeaderField: "User-Agent")
+        let (data, _) = try await urlSession.data(for: request)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let retValue = json["retValue"] as? [String: Any],
+              let modulus = retValue["n"] as? String,
+              let exponent = retValue["e"] as? String,
+              let kid = retValue["kid"] as? String else {
+            throw APIError(message: "Failed to parse JWK from /accounts/certs", apiName: apiName)
+        }
+        return HyundaiEuropeJWK(modulus: modulus, exponent: exponent, kid: kid)
+    }
+
+    /// Step 3: POST signin as form data. URLSession follows IDP redirects;
+    /// the final response URL carries either `code` or an actionable error page.
+    private func submitSignin(encryptedHex: String, kid: String, state: String) async throws -> URLResponse {
+        let fields: [(String, String)] = [
+            ("client_id", Self.clientId),
+            ("encryptedPassword", "true"),
+            ("password", encryptedHex),
+            ("redirect_uri", oauthRedirectURI),
+            ("scope", ""),
+            ("nonce", ""),
+            ("state", state),
+            ("username", username),
+            ("connector_session_key", ""),
+            ("kid", kid),
+            ("_csrf", "")
+        ]
+        var request = URLRequest(url: URL(string: "\(authBaseURL)/auth/account/signin")!)
+        request.httpMethod = "POST"
+        request.setValue(Self.mobileUserAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formEncode(fields).data(using: .utf8)
+        let (_, response) = try await urlSession.data(for: request)
+        return response
+    }
+
+    /// Parse the signin redirect for `code`, or translate browser-only
+    /// account/captcha/login redirects into useful API errors.
+    private func parseSigninCode(from response: URLResponse, expectedState: String) throws -> String {
+        guard let http = response as? HTTPURLResponse,
+              let finalURL = http.url,
+              let comps = URLComponents(url: finalURL, resolvingAgainstBaseURL: false) else {
+            throw APIError.invalidCredentials("Signin returned no redirect", apiName: apiName)
+        }
+
+        if let code = comps.queryItems?.first(where: { $0.name == "code" })?.value,
+           !code.isEmpty {
+            let returnedState = comps.queryItems?.first(where: { $0.name == "state" })?.value
+            guard returnedState == expectedState else {
+                throw APIError.invalidCredentials("Signin state mismatch", apiName: apiName)
+            }
+            return code
+        }
+
+        if let error = actionableSigninRedirectError(from: finalURL, components: comps) {
+            throw error
+        }
+
+        throw APIError(message: "Unexpected redirect after signin: \(finalURL.absoluteString)", apiName: apiName)
+    }
+
+    private func actionableSigninRedirectError(from finalURL: URL, components: URLComponents) -> APIError? {
+        if let errorDesc = components.queryItems?.first(where: { $0.name == "error_description" })?.value {
+            return APIError.invalidCredentials("Authentication rejected: \(errorDesc)", apiName: apiName)
+        }
+        if let error = components.queryItems?.first(where: { $0.name == "error" })?.value {
+            return APIError.invalidCredentials("Authentication rejected: \(error)", apiName: apiName)
+        }
+
+        let path = components.path.lowercased()
+        let absolute = finalURL.absoluteString.lowercased()
+        if path.contains("captcha") || absolute.contains("captcha") {
+            return APIError(
+                message: "Hyundai account requires CAPTCHA verification. Sign in in a browser once, then try again.",
+                apiName: apiName
+            )
+        }
+        if path.contains("authorization") || path.contains("consent") || absolute.contains("terms") {
+            return APIError(
+                message: "Hyundai account consent is required. Sign in in a browser once to accept the terms.",
+                apiName: apiName
+            )
+        }
+        if path.contains("/auth/account/signin") || absolute.contains("login") {
+            return APIError.invalidCredentials(
+                "Authentication returned to the Hyundai login page. Check username and password.",
+                apiName: apiName
+            )
+        }
+        return nil
+    }
+
+    /// Exchange `code` from the signin redirect for access + refresh tokens.
+    func exchangeForToken(code: String) async throws -> AuthToken {
+        let fields: [(String, String)] = [
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", oauthRedirectURI),
+            ("client_id", Self.clientId),
+            ("client_secret", Self.clientSecret)
+        ]
+        return try await postTokenRequest(fields: fields, isRefresh: true)
+    }
+
+    /// Refresh-grant: trade stored refresh_token for a fresh access_token.
+    func getAccessTokenFromRefreshToken() async throws -> AuthToken {
+        let fields: [(String, String)] = [
+            ("grant_type", "refresh_token"),
+            ("refresh_token", configuration.refreshToken ?? ""),
+            ("redirect_uri", oauthRedirectURI),
+            ("client_id", Self.clientId),
+            ("client_secret", Self.clientSecret)
+        ]
+        return try await postTokenRequest(fields: fields, isRefresh: false)
+    }
+
+    /// Shared POST /oauth2/token helper for authorization-code and refresh grants.
+    private func postTokenRequest(fields: [(String, String)], isRefresh: Bool) async throws -> AuthToken {
+        var request = URLRequest(url: URL(string: "\(authBaseURL)/auth/api/v2/user/oauth2/token")!)
+        request.httpMethod = "POST"
+        request.setValue(Self.mobileUserAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formEncode(fields).data(using: .utf8)
+        let (data, _) = try await urlSession.data(for: request)
+        return try parseAuthToken(from: data, isRefresh: isRefresh)
+    }
+}

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Commands.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Commands.swift
@@ -17,10 +17,10 @@ extension HyundaiEuropeAPIClient {
         switch command {
         case .lock:
             return ccs2 ? ("ccs2/control/door", ["command": "close"])
-            : ("/control/door", ["action": "close", "deviceId": deviceId])
+            : ("control/door", ["action": "close", "deviceId": deviceId])
         case .unlock:
             return ccs2 ? ("ccs2/control/door", ["command": "open"])
-            : ("/control/door", ["action": "open", "deviceId": deviceId])
+            : ("control/door", ["action": "open", "deviceId": deviceId])
         case .startClimate(let options):
             // EU vehicles share ApiImplType1.start_climate across
             // both brands — CCS2 uses a flat body (same as Kia EU);
@@ -100,5 +100,14 @@ extension HyundaiEuropeAPIClient {
             "tempUnit": "C",
             "windshieldFrontDefogState": options.defrost
         ]
+    }
+}
+
+extension VehicleCommand {
+    var isChargeLimitCommand: Bool {
+        if case .setTargetSOC = self {
+            return true
+        }
+        return false
     }
 }

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Headers.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Headers.swift
@@ -12,6 +12,7 @@
 
 import CryptoKit
 import Foundation
+import Security
 
 extension HyundaiEuropeAPIClient {
 
@@ -34,13 +35,6 @@ extension HyundaiEuropeAPIClient {
         ]
     }
 
-    func loginHeaders() -> [String: String] {
-        ["Content-Type": "application/json",
-         "Accept-Encoding": "gzip",
-         "User-Agent": "okhttp/3.14.9"
-        ]
-    }
-
     func commandHeaders(authToken: AuthToken, ccs2: Bool = false) -> [String: String] {
         var result = authorizedHeaders(authToken: authToken, ccs2: ccs2)
         result["Authorization"] = "Bearer \(commandToken)"
@@ -50,8 +44,7 @@ extension HyundaiEuropeAPIClient {
 
     /// HMAC-SHA256 of `<appId>:<ISO8601 timestamp>` keyed by the
     /// first 32 bytes of the base64-decoded `authCfb` shared secret,
-    /// base64-encoded. Sent as the `Stamp` header on every request
-    /// and as the `pushRegId` field during device registration.
+    /// base64-encoded. Sent as the `Stamp` header on every request.
     func generateStamp() -> String {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let message = "\(Self.appId):\(timestamp)"
@@ -59,5 +52,97 @@ extension HyundaiEuropeAPIClient {
         let key = SymmetricKey(data: cfbData.prefix(32))
         let signature = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: key)
         return Data(signature).base64EncodedString()
+    }
+
+    // MARK: - RSA / encoding helpers
+
+    /// PKCS#1 v1.5 encrypt `password` with the RSA public key described by
+    /// the JWK `(n, e)` pair, returning a lowercase hex string.
+    func rsaEncryptPKCS1(password: String, jwkN: String, jwkE: String) throws -> String {
+        guard let nData = Self.base64urlDecode(jwkN),
+              let eData = Self.base64urlDecode(jwkE) else {
+            throw APIError(message: "Invalid base64url in JWK", apiName: apiName)
+        }
+        let derKey = Self.rsaPublicKeyDER(modulus: nData, exponent: eData)
+        let attributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass as String: kSecAttrKeyClassPublic,
+            kSecAttrKeySizeInBits as String: nData.count * 8
+        ]
+        var error: Unmanaged<CFError>?
+        guard let secKey = SecKeyCreateWithData(derKey as CFData, attributes as CFDictionary, &error) else {
+            throw APIError(
+                message: "Failed to construct RSA key: " +
+                    "\(error?.takeRetainedValue().localizedDescription ?? "unknown")",
+                apiName: apiName
+            )
+        }
+        let plaintext = Data(password.utf8)
+        guard let encrypted = SecKeyCreateEncryptedData(
+            secKey, .rsaEncryptionPKCS1, plaintext as CFData, &error
+        ) else {
+            throw APIError(
+                message: "RSA encryption failed: " +
+                    "\(error?.takeRetainedValue().localizedDescription ?? "unknown")",
+                apiName: apiName
+            )
+        }
+        return (encrypted as Data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    func randomHexString(byteCount: Int) throws -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw APIError(message: "Failed to generate random push registration id", apiName: apiName)
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func base64urlDecode(_ input: String) -> Data? {
+        var padded = input.replacingOccurrences(of: "-", with: "+")
+                          .replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - padded.count % 4) % 4
+        if pad > 0 { padded.append(String(repeating: "=", count: pad)) }
+        return Data(base64Encoded: padded)
+    }
+
+    /// Build a PKCS#1 RSAPublicKey DER blob (`SEQUENCE { INTEGER n, INTEGER e }`),
+    /// which is what `SecKeyCreateWithData` expects for a raw RSA public key.
+    static func rsaPublicKeyDER(modulus: Data, exponent: Data) -> Data {
+        let nDER = derInteger(modulus)
+        let eDER = derInteger(exponent)
+        return derTLV(tag: 0x30, value: nDER + eDER)
+    }
+
+    private static func derInteger(_ bytes: Data) -> Data {
+        let value: Data = (bytes.first ?? 0) >= 0x80 ? Data([0x00]) + bytes : bytes
+        return derTLV(tag: 0x02, value: value)
+    }
+
+    private static func derTLV(tag: UInt8, value: Data) -> Data {
+        var out = Data([tag])
+        let len = value.count
+        if len < 0x80 {
+            out.append(UInt8(len))
+        } else if len < 0x100 {
+            out.append(0x81)
+            out.append(UInt8(len))
+        } else {
+            out.append(0x82)
+            out.append(UInt8((len >> 8) & 0xff))
+            out.append(UInt8(len & 0xff))
+        }
+        return out + value
+    }
+
+    /// RFC 3986 form-encode a list of key/value pairs (order preserved).
+    static func formEncode(_ fields: [(String, String)]) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+        return fields.map { key, value in
+            let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
+            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+            return "\(encodedKey)=\(encodedValue)"
+        }.joined(separator: "&")
     }
 }

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Parsing.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Parsing.swift
@@ -118,6 +118,93 @@ extension HyundaiEuropeAPIClient {
             )
     }
 
+    package func hyundaiEuropeAPIError(from data: Data) -> APIError? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let resCode = (json["resCode"] as? String) ?? (json["resCode"] as? Int).map({ String($0) }),
+              let retCode = json["retCode"] as? String else {
+            return nil
+        }
+
+        guard retCode == "F" || resCode != "0000" else {
+            return nil
+        }
+
+        let serverMessage = hyundaiEuropeServerMessage(from: json["resMsg"])
+        let message = hyundaiEuropeErrorMessage(resCode: resCode, serverMessage: serverMessage)
+        let code = Int(resCode)
+        let userInfo = [
+            "retCode": retCode,
+            "resCode": resCode
+        ]
+
+        return APIError.logError(
+            message,
+            code: code,
+            apiName: apiName,
+            errorType: hyundaiEuropeErrorType(resCode: resCode),
+            userInfo: userInfo
+        )
+    }
+
+    private func hyundaiEuropeErrorType(resCode: String) -> APIError.ErrorType {
+        switch resCode {
+        case "7501":
+            return .invalidCredentials
+        case "4002":
+            return .invalidVehicleSession
+        case "4004":
+            return .concurrentRequest
+        case "4081", "9999", "5031", "5091":
+            return .serverError
+        default:
+            return .general
+        }
+    }
+
+    private func hyundaiEuropeErrorMessage(resCode: String, serverMessage: String?) -> String {
+        let baseMessage: String = switch resCode {
+        case "7501":
+            "Hyundai EU authentication expired or was rejected. Sign in again."
+        case "4002":
+            "Hyundai EU device registration is invalid or stale. Register the device again."
+        case "4004":
+            "Another Hyundai EU vehicle command is already in progress. Wait a moment and try again."
+        case "4005":
+            "Hyundai EU rejected this request as unsupported or invalid for the vehicle."
+        case "4081":
+            "Hyundai EU command timed out. Check the vehicle state and try again."
+        case "5031":
+            "Hyundai EU service is temporarily unavailable. Try again later."
+        case "5091":
+            "Hyundai EU rate limit reached. Wait before retrying."
+        case "5921":
+            "Hyundai EU returned no data for this vehicle."
+        case "9999":
+            "Hyundai EU returned a temporary server error. Try again later."
+        default:
+            "Hyundai EU request failed with response code \(resCode)."
+        }
+        guard let serverMessage, !serverMessage.isEmpty else {
+            return baseMessage
+        }
+        return "\(baseMessage) Server message: \(serverMessage)"
+    }
+
+    private func hyundaiEuropeServerMessage(from resMsg: Any?) -> String? {
+        if let message = resMsg as? String {
+            return message
+        }
+        guard let dict = resMsg as? [String: Any] else {
+            return nil
+        }
+        for key in ["message", "msg", "errorMessage", "description"] {
+            if let message = dict[key] as? String {
+                return message
+            }
+        }
+        return nil
+    }
+
     private func parseEVStatus(from vehicleState: [String: Any], pathMap: HyEuResponseKeyPathMap)
         -> VehicleStatus.EVStatus? {
 

--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient.swift
@@ -6,7 +6,6 @@
 //  Based on: https://github.com/andyfase/egmp-bluelink-scriptable
 //
 
-import CryptoKit
 import Foundation
 
 // MARK: - Hyundai Europe API Client
@@ -20,6 +19,11 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
     static let clientSecret = "KUy49XxPzLpLuoK0xhBC77W6VXhmtQR9iQhmIFjjoY4IpxsV"
     static let appId = "014d2225-8495-4735-812d-2616334fd15d"
     static let authCfb = "RFtoRq/vDXJmRndoZaZQyfOot7OrIqGVFj96iY2WL3yyH5Z/pUvlUhqmCxD2t+D65SQ="
+    static let mobileUserAgent =
+        "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) " +
+        "AppleWebKit/535.19 (KHTML, like Gecko) " +
+        "Chrome/18.0.1025.166 Mobile Safari/535.19_CCS_APP_AOS"
+
     var commandToken: String = ""
     var commandTokenExpiration: Date = Date()
 
@@ -28,6 +32,8 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
     }
     var authBaseURL: String { "https://idpconnect-eu.hyundai.com" }
     var apiHost =  Brand.hyundaiBaseUrl(region: Region.europe).replacing(/https:\/\//, with: "")
+
+    var oauthRedirectURI: String { "\(baseURL)/api/v1/user/oauth2/redirect" }
 
     public override var apiName: String { "HyundaiEurope" }
 
@@ -67,93 +73,11 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
         return token
     }
 
-    /// use code to exchange it for access token
-    private func exchangeForToken(code: String) async throws -> AuthToken {
-
-        let body = [
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": "\(baseURL)/api/v1/user/oauth2/token",
-            "client_id": Self.clientId,
-            "client_secret": Self.clientSecret
-        ]
-
-        let (data, _, _) = try await performJSONRequest(
-            url: "\(authBaseURL)/auth/api/v2/user/oauth2/token",
-            method: .POST,
-            headers: loginHeaders(),
-            body: body,
-            requestType: .login
-        )
-
-        return try parseAuthToken(from: data, isRefresh: true)
-    }
-
-    /// use username and password to get code for token exchange
-    private func signin() async throws -> String {
-        let state = UUID().uuidString
-        let body = ["client_id": Self.clientId,
-                    "encryptedPassword": "false",
-                    "username": username,
-                    "password": password,
-                    "redirect_uri": "\(baseURL)/api/v1/user/oauth2/token",
-                    "state": state,
-                    "remember_me": "false"
-        ]
-
-        let bodyData = try? JSONSerialization.data(
-            withJSONObject: body, options: []
-        )
-
-        var request = URLRequest(url: URL(string: "\(authBaseURL)/auth/account/signin")!)
-        request.httpMethod = "POST"
-        request.httpBody = bodyData
-        request.allHTTPHeaderFields = loginHeaders()
-        let (_, response) = try await urlSession.data(for: request)
-
-        guard let http = response as? HTTPURLResponse,
-              let finalURL = http.url,
-              let comps = URLComponents(url: finalURL, resolvingAgainstBaseURL: false) else {
-            return ""
-        }
-        // State validate ← no possible anymore CSRF
-        guard comps.queryItems?.first(where: { $0.name == "state" })?.value == state else {
-                return ""
-        }
-        guard let code = comps.queryItems?.first(where: { $0.name == "code" })?.value,
-                  !code.isEmpty else {
-                return ""
-        }
-
-        return code
-    }
-
-    /// use refresh token to get a fresh acces token
-    private func getAccessTokenFromRefreshToken() async throws -> AuthToken {
-
-        let body = [
-            "grant_type": "refresh_token",
-            "refresh_token": configuration.refreshToken,
-            "client_id": Self.clientId,
-            "client_secret": Self.clientSecret
-        ]
-
-        let bodyData = try? JSONSerialization.data(
-            withJSONObject: body, options: []
-        )
-
-        var request = URLRequest(url: URL(string: "\(authBaseURL)/auth/api/v2/user/oauth2/token")!)
-        request.httpMethod = "POST"
-        request.httpBody = bodyData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        let (data, _) = try await urlSession.data(for: request)
-        return try parseAuthToken(from: data, isRefresh: false)
-    }
-
     public override func registerDevice() async throws -> String? {
         let stamp = generateStamp()
+        let pushRegId = try randomHexString(byteCount: 32)
         let body = [
-            "pushRegId": stamp,
+            "pushRegId": pushRegId,
             "pushType": "GCM",
             "uuid": UUID().uuidString
         ]
@@ -278,15 +202,19 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
 
     public func sendCommand(for vehicle: Vehicle, command: VehicleCommand, authToken: AuthToken) async throws {
         let ccs2 = vehicle.marketOptions?.ccs2Supported ?? false
-        // Pass the vehicle's actual protocol into the body builder.
-        // Previously this used the default (ccs2: true), so a legacy
-        // Hyundai EU vehicle got a v1 URL with CCS2-shaped bodies.
-        let (path, body) = commandPathAndBody(for: command, ccs2: ccs2)
+        let usesControlToken = ccs2 && !command.isChargeLimitCommand
+        let (rawPath, body) = commandPathAndBody(for: command, ccs2: ccs2)
+        let path = String(rawPath.drop { $0 == "/" })
         let url =
-            "\(baseURL)/api/\(ccs2 ? "v2" : "v1")"
+            "\(baseURL)/api/\(usesControlToken ? "v2" : "v1")"
             + "/spa/vehicles/\(vehicle.regId)/\(path)"
-        try await setCommandToken(authToken: authToken)
-        let header = commandHeaders(authToken: authToken, ccs2: ccs2)
+        let header: [String: String]
+        if usesControlToken {
+            try await setCommandToken(authToken: authToken)
+            header = commandHeaders(authToken: authToken, ccs2: ccs2)
+        } else {
+            header = authorizedHeaders(authToken: authToken, ccs2: ccs2)
+        }
 
         _ = try await performJSONRequest(
             url: url,
@@ -296,5 +224,12 @@ public final class HyundaiEuropeAPIClient: APIClientBase, APIClientProtocol {
             requestType: .sendCommand,
             vin: vehicle.vin
         )
+    }
+
+    override func validateHTTPResponse(_ httpResponse: HTTPURLResponse, data: Data, responseBody: String?) throws {
+        if let error = hyundaiEuropeAPIError(from: data) {
+            throw error
+        }
+        try super.validateHTTPResponse(httpResponse, data: data, responseBody: responseBody)
     }
 }

--- a/Tests/BetterBlueKitTests/HyEuAPIParsingTests.swift
+++ b/Tests/BetterBlueKitTests/HyEuAPIParsingTests.swift
@@ -1039,3 +1039,301 @@ struct HyJSONFormatTests {
         #expect(vehicleStatus.engineOn == true)
     }
 }
+
+private struct HyEuRecordedRequest {
+    let url: URL
+    let method: String
+    let headers: [String: String]
+    let body: Data?
+}
+
+private final class HyEuMockURLProtocol: URLProtocol, @unchecked Sendable {
+    typealias Handler = (URLRequest) throws -> (HTTPURLResponse, Data)
+
+    nonisolated(unsafe) private static var requestHandler: Handler?
+    nonisolated(unsafe) private static var recordedRequests: [HyEuRecordedRequest] = []
+
+    static func reset(handler: @escaping Handler) {
+        recordedRequests = []
+        requestHandler = handler
+    }
+
+    static var requests: [HyEuRecordedRequest] {
+        recordedRequests
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            guard let url = request.url else {
+                throw NSError(domain: "HyEuMockURLProtocol", code: 1)
+            }
+            Self.recordedRequests.append(HyEuRecordedRequest(
+                url: url,
+                method: request.httpMethod ?? "GET",
+                headers: request.allHTTPHeaderFields ?? [:],
+                body: Self.bodyData(from: request)
+            ))
+            guard let requestHandler = Self.requestHandler else {
+                throw NSError(domain: "HyEuMockURLProtocol", code: 2)
+            }
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break
+            }
+        }
+        return data.isEmpty ? nil : data
+    }
+}
+
+@MainActor
+private func makeHyEuClient(
+    deviceId: String = "device-123",
+    refreshToken: String? = nil,
+    handler: @escaping HyEuMockURLProtocol.Handler
+) -> HyundaiEuropeAPIClient {
+    HyEuMockURLProtocol.reset(handler: handler)
+    let sessionConfig = URLSessionConfiguration.ephemeral
+    sessionConfig.protocolClasses = [HyEuMockURLProtocol.self]
+    let session = URLSession(configuration: sessionConfig)
+    let config = APIClientConfiguration(
+        region: .europe,
+        brand: .hyundai,
+        username: "test@example.com",
+        password: "password123",
+        refreshToken: refreshToken,
+        pin: "0000",
+        accountId: UUID(),
+        deviceId: deviceId
+    )
+    return HyundaiEuropeAPIClient(configuration: config, urlSession: session)
+}
+
+private func hyEuResponse(for url: URL, status: Int = 200) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+private func header(_ name: String, in request: HyEuRecordedRequest) -> String? {
+    request.headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
+}
+
+private func jsonBody(from request: HyEuRecordedRequest) throws -> [String: Any] {
+    let data = try #require(request.body)
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    return try #require(json)
+}
+
+@Suite("Hyundai Europe Request Routing", .serialized)
+struct HyEuRequestRoutingTests {
+
+    private let successData = Data(#"{"retCode":"S","resCode":"0000","resMsg":{}}"#.utf8)
+    private let authToken = AuthToken(
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date().addingTimeInterval(3600)
+    )
+
+    @Test("Legacy commands use v1 control path with normal auth headers")
+    @MainActor func legacyCommandUsesV1NormalAuth() async throws {
+        let client = makeHyEuClient { request in
+            (hyEuResponse(for: request.url!), successData)
+        }
+        let vehicle = hyEuVehicle(regId: "legacy-id", ccs2: false)
+
+        try await client.sendCommand(for: vehicle, command: .lock, authToken: authToken)
+
+        let request = try #require(HyEuMockURLProtocol.requests.first)
+        #expect(HyEuMockURLProtocol.requests.count == 1)
+        #expect(request.method == "POST")
+        #expect(request.url.path == "/api/v1/spa/vehicles/legacy-id/control/door")
+        #expect(header("Authorization", in: request) == "Bearer access-token")
+        #expect(header("AuthorizationCCSP", in: request) == nil)
+        #expect(header("Ccuccs2protocolsupport", in: request) == "0")
+
+        let body = try jsonBody(from: request)
+        #expect(body["action"] as? String == "close")
+        #expect(body["deviceId"] as? String == "device-123")
+    }
+
+    @Test("CCS2 commands use v2 ccs2 path with control token headers")
+    @MainActor func ccs2CommandUsesV2ControlTokenAuth() async throws {
+        let controlData = Data(#"{"controlToken":"control-token","expiresTime":600}"#.utf8)
+        let client = makeHyEuClient { request in
+            if request.url?.path == "/api/v1/user/pin" {
+                return (hyEuResponse(for: request.url!), controlData)
+            }
+            return (hyEuResponse(for: request.url!), successData)
+        }
+        let vehicle = hyEuVehicle(regId: "ccs2-id", ccs2: true)
+
+        try await client.sendCommand(for: vehicle, command: .unlock, authToken: authToken)
+
+        let requests = HyEuMockURLProtocol.requests
+        #expect(requests.count == 2)
+        let commandRequest = try #require(requests.last)
+        #expect(commandRequest.url.path == "/api/v2/spa/vehicles/ccs2-id/ccs2/control/door")
+        #expect(header("Authorization", in: commandRequest) == "Bearer control-token")
+        #expect(header("AuthorizationCCSP", in: commandRequest) == "Bearer control-token")
+        #expect(header("Ccuccs2protocolsupport", in: commandRequest) == "1")
+
+        let body = try jsonBody(from: commandRequest)
+        #expect(body["command"] as? String == "open")
+    }
+
+    @Test("Charge limits use v1 normal auth and DC before AC plug types")
+    @MainActor func chargeLimitsUseV1NormalAuth() async throws {
+        try await assertChargeLimitRequest(ccs2: false, expectedHeader: "0")
+        try await assertChargeLimitRequest(ccs2: true, expectedHeader: "1")
+    }
+
+    @Test("Device registration sends random pushRegId and Stamp only as header")
+    @MainActor func deviceRegistrationUsesRandomPushRegId() async throws {
+        let client = makeHyEuClient { request in
+            let response = Data(#"{"resMsg":{"deviceId":"registered-device"}}"#.utf8)
+            return (hyEuResponse(for: request.url!), response)
+        }
+
+        let deviceId = try await client.registerDevice()
+
+        #expect(deviceId == "registered-device")
+        let request = try #require(HyEuMockURLProtocol.requests.first)
+        #expect(request.url.path == "/api/v1/spa/notifications/register")
+        let body = try jsonBody(from: request)
+        let pushRegId = try #require(body["pushRegId"] as? String)
+        let stamp = try #require(header("Stamp", in: request))
+        #expect(pushRegId.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil)
+        #expect(pushRegId != stamp)
+        #expect(body["pushType"] as? String == "GCM")
+    }
+
+    @Test("EU body errors map to actionable APIError types")
+    @MainActor func bodyErrorsMapToAPIErrorTypes() throws {
+        let client = makeHyEuClient { request in
+            (hyEuResponse(for: request.url!), Data())
+        }
+        let cases: [(String, APIError.ErrorType)] = [
+            ("7501", .invalidCredentials),
+            ("4002", .invalidVehicleSession),
+            ("4004", .concurrentRequest),
+            ("4005", .general),
+            ("4081", .serverError),
+            ("9999", .serverError),
+            ("5031", .serverError),
+            ("5091", .serverError),
+            ("5921", .general)
+        ]
+
+        for (resCode, errorType) in cases {
+            let data = Data(#"{"retCode":"F","resCode":"\#(resCode)","resMsg":{"message":"server message"}}"#.utf8)
+            let error = try #require(client.hyundaiEuropeAPIError(from: data))
+            #expect(error.errorType == errorType)
+            #expect(error.code == Int(resCode))
+            #expect(error.message.contains("server message"))
+        }
+    }
+
+    @Test("Token exchange posts form data")
+    @MainActor func tokenExchangePostsFormData() async throws {
+        let tokenData = Data("""
+        {"access_token":"access-token","refresh_token":"new-refresh","expires_in":3600}
+        """.utf8)
+        let client = makeHyEuClient { request in
+            (hyEuResponse(for: request.url!), tokenData)
+        }
+
+        let token = try await client.exchangeForToken(code: "returned-code")
+
+        #expect(token.accessToken == "access-token")
+        #expect(token.refreshToken == "new-refresh")
+        let request = try #require(HyEuMockURLProtocol.requests.first)
+        let body = String(data: try #require(request.body), encoding: .utf8)
+        #expect(request.url.path == "/auth/api/v2/user/oauth2/token")
+        #expect(header("Content-Type", in: request) == "application/x-www-form-urlencoded")
+        #expect(body?.contains("grant_type=authorization_code") == true)
+        #expect(body?.contains("code=returned-code") == true)
+        #expect(body?.contains("redirect_uri=https%3A%2F%2Fprd.eu-ccapi.hyundai.com%3A8080%2Fapi%2Fv1%2Fuser%2Foauth2%2Fredirect") == true)
+    }
+
+    @Test("Login form helpers encode reserved characters")
+    @MainActor func loginFormHelpersEncodeReservedCharacters() throws {
+        let encoded = HyundaiEuropeAPIClient.formEncode([
+            ("redirect_uri", "https://example.com/callback?a=1&b=two words"),
+            ("password", "p+a&b=c")
+        ])
+        #expect(encoded == "redirect_uri=https%3A%2F%2Fexample.com%2Fcallback%3Fa%3D1%26b%3Dtwo%20words&password=p%2Ba%26b%3Dc")
+        #expect(HyundaiEuropeAPIClient.base64urlDecode("SGVsbG8td29ybGQ") == Data("Hello-world".utf8))
+    }
+
+    @MainActor private func assertChargeLimitRequest(ccs2: Bool, expectedHeader: String) async throws {
+        let client = makeHyEuClient { request in
+            (hyEuResponse(for: request.url!), successData)
+        }
+        let vehicle = hyEuVehicle(regId: ccs2 ? "ccs2-id" : "legacy-id", ccs2: ccs2)
+
+        try await client.sendCommand(
+            for: vehicle,
+            command: .setTargetSOC(acLevel: 80, dcLevel: 90),
+            authToken: authToken
+        )
+
+        #expect(HyEuMockURLProtocol.requests.count == 1)
+        let request = try #require(HyEuMockURLProtocol.requests.first)
+        #expect(request.url.path == "/api/v1/spa/vehicles/\(vehicle.regId)/charge/target")
+        #expect(header("Authorization", in: request) == "Bearer access-token")
+        #expect(header("AuthorizationCCSP", in: request) == nil)
+        #expect(header("Ccuccs2protocolsupport", in: request) == expectedHeader)
+
+        let body = try jsonBody(from: request)
+        let targets = try #require(body["targetSOClist"] as? [[String: Any]])
+        let dcTarget = try #require(targets.first { $0["plugType"] as? Int == 0 })
+        let acTarget = try #require(targets.first { $0["plugType"] as? Int == 1 })
+        #expect(dcTarget["targetSOClevel"] as? Int == 90)
+        #expect(acTarget["targetSOClevel"] as? Int == 80)
+    }
+
+    private func hyEuVehicle(regId: String, ccs2: Bool) -> Vehicle {
+        Vehicle(
+            vin: "TESTVIN\(regId)",
+            regId: regId,
+            model: "IONIQ",
+            accountId: UUID(),
+            fuelType: .electric,
+            generation: 2,
+            odometer: Distance(length: 0, units: .kilometers),
+            marketOptions: .hyundaiEurope(ccs2Supported: ccs2)
+        )
+    }
+}


### PR DESCRIPTION
# Add Hyundai Europe auth, command routing, and parsing support

## Summary
- Implements Hyundai Europe IDPConnect login using the current RSA-encrypted password flow, including `/auth/api/v1/accounts/certs`, encrypted password sign-in, token exchange, and refresh-token reuse.
- Updates Hyundai Europe headers and device registration/control-token handling.
- Routes Gen5W/non-CCS2 commands through the v1 SPA control endpoints with normal authorized headers, while keeping CCS2 commands on the v2 CCS2 control endpoints with control-token headers.
- Adds Hyundai Europe status parsing for legacy/non-CCS2 and CCS2 response shapes, including CCS2 capability detection, EV data, location fallback, lock/climate state, and target SOC values.
- Maps common Hyundai Europe JSON error codes into actionable `APIError` cases/messages instead of surfacing generic failures.
- Extends `bbcli parse` support and adds Hyundai Europe request routing/parsing tests.

## Testing
- `swift test`
  - Passed: 297 tests in 34 suites.
- Integration compile check from BetterBlue with this BetterBlueKit commit:
  - `xcodebuild -project BetterBlue.xcodeproj -scheme BetterBlue -configuration Debug -destination id=8BC65052-BD69-40DB-9C74-A5EDEDA16E4F -derivedDataPath /private/tmp/BetterBlueUpstreamPRDerivedData build`
  - Passed: `BUILD SUCCEEDED`.

## Notes
- The command-routing split is based on the vehicle response: non-CCS2/Gen5W vehicles use the v1 SPA control path, while CCS2-capable vehicles keep the existing v2 CCS2 control path.
- No real vehicle lock/unlock/climate/charge command was sent during automated verification.
