### PR TITLE
Locale-aware number formatting in Distance/Temperature (fixes ungrouped odometer)

### DIFF
--- a/Sources/BetterBlueKit/Models/Measurements.swift
+++ b/Sources/BetterBlueKit/Models/Measurements.swift
@@ -35,6 +35,10 @@ public struct Distance: Codable, Hashable, Sendable {
             let convertedLength = convert(length, to: targetUnits)
 
             let formatter = NumberFormatter()
+            // .decimal applies the current locale's grouping separator (e.g. "19,500"
+            // in en-US, "19.500" in de-DE, "19 500" in fr-FR). The default .none style
+            // applies no grouping, so a 19,500 mi odometer rendered as "19500".
+            formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 0
             let formattedNumber = formatter.string(from: NSNumber(value: convertedLength)) ?? "0"
 
@@ -90,6 +94,10 @@ public struct Temperature: Codable, Hashable, Sendable {
             // show up to one decimal ("22.5°C", "22°C"). Fahrenheit is
             // whole-degree only.
             let formatter = NumberFormatter()
+            // .decimal makes the decimal separator locale-correct (half-degree Celsius
+            // shows "22,5°C" in de-DE, not "22.5°C"); the per-unit maximumFractionDigits
+            // set below still applies.
+            formatter.numberStyle = .decimal
             let displayValue: Double
             switch targetUnits {
             case .celsius:

--- a/Tests/BetterBlueKitTests/MeasurementsTests.swift
+++ b/Tests/BetterBlueKitTests/MeasurementsTests.swift
@@ -91,6 +91,17 @@ struct MeasurementsTests {
         #expect(formatted == "100 mi")
     }
 
+    @Test("Distance Units format groups thousands (locale-aware)")
+    func testDistanceUnitsFormatGroupsThousands() {
+        // A 19,500 mi odometer must not render as the ungrouped "19500".
+        // numberStyle = .decimal applies the current locale's grouping separator
+        // ("19,500" en-US, "19.500" de-DE, "19 500" fr-FR), so assert that grouping
+        // happened rather than a specific separator (keeps the test locale-independent).
+        let formatted = Distance.Units.miles.format(19500.0, to: .miles)
+        #expect(!formatted.contains("19500"))
+        #expect(formatted.hasSuffix(" mi"))
+    }
+
     @Test("Distance Codable")
     func testDistanceCodable() throws {
         let original = Distance(length: 150.5, units: .kilometers)


### PR DESCRIPTION
## What this does

`Distance.Units.format` and `Temperature.Units.format` build a `NumberFormatter` but never set `numberStyle`, so it defaults to `.none` — which applies **no grouping separator** and a hardcoded `.` decimal separator. Two user-visible consequences:

- **Odometer / range** render ungrouped: a 19,500 mi odometer shows as **`19500`** instead of `19,500`.
- **Half-degree Celsius** (the `maximumFractionDigits = 1` path) shows a hardcoded period: `22.5°C` even in locales that use a comma.

Setting `formatter.numberStyle = .decimal` makes both **locale-aware**. `maximumFractionDigits` is still set afterward, so whole-number distances and Fahrenheit stay integer-only.

Because everything funnels through these two shared formatters, this fixes the odometer/range everywhere they appear (in-app, widget, Live Activity, Watch + complications, Trip view) with no call-site changes. It matters beyond the US — BetterBlue supports Hyundai US/CA/EU and Kia US/EU, and EU + French-Canada users use period/space grouping.

| value | before | en-US | de-DE | fr-FR |
|---|---|---|---|---|
| 19,500 mi odometer | `19500 mi` | `19,500 mi` | `19.500 mi` | `19 500 mi` |
| 22.5 °C | `22.5°C` | `22.5°C` | `22,5°C` | `22,5°C` |

## Testing

`swift test` — **291 tests pass**. Added `testDistanceUnitsFormatGroupsThousands`, which asserts grouping happens without pinning a specific separator, so it stays locale-independent across CI. Existing format assertions are unaffected (their values are < 1000, where no grouping appears).

---
*Drafted with AI assistance; verified locally with `swift test`.*
