### PR TITLE
HyundaiEurope: fix app crash from force-unwrapping a non-numeric status field

### DIFF
--- a/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Parsing.swift
+++ b/Sources/BetterBlueKit/API/HyundaiEurope/HyundaiEuropeAPIClient+Parsing.swift
@@ -314,7 +314,7 @@ extension HyundaiEuropeAPIClient {
         switch getAnyFromJson(from: data, key: keyString!) {
         case let value as Double: return value
         case let value as Int: return Double(value)
-        case let value as String: return Double(value)!
+        case let value as String: return Double(value) ?? 0
         default: return 0
         }
     }


### PR DESCRIPTION
## What this does

`HyundaiEuropeAPIClient.getDoubleFromJson` force-unwraps the optional `Double(String)`:

```swift
case let value as String: return Double(value)!
```

If the API returns a numeric status field as a non-numeric string — empty, `"null"`, `"--"`, a unit-suffixed value, or a comma-decimal — `Double(value)` is `nil` and the `!` traps, **crashing the app while parsing a vehicle status**. This helper feeds odometer, SOC, range, GPS and similar fields, so one malformed value takes the app down. Hyundai EU is already one of the rougher regions (EU login/command reports in the tracker), which makes a hard crash here especially worth removing.

The fix matches the **Kia EU sibling**, which already does the safe thing (`KiaEuropeAPIClient+Parsing.swift`):

```swift
case let value as String: return Double(value) ?? 0
```

`0` is also this function's existing `default:` fallback, so the behavior is consistent — a non-numeric value now reads as `0` instead of crashing.

## Testing

`swift test` — **290 tests pass**. The existing Hyundai EU parsing tests cover the happy path, which is unchanged; this only affects the previously-crashing non-numeric case. Pure one-line safety change with no behavior change for valid payloads.

---
*Drafted with AI assistance; verified locally with `swift test`.*
