### PR TITLE
HyundaiCanada: convert HI/LOW air-temp to resolved unit (fixes 62°C/82°C dropout, issue #30)

### DIFF
--- a/Sources/BetterBlueKit/API/HyundaiCanadaAPI/HyundaiCanada+StatusParsing.swift
+++ b/Sources/BetterBlueKit/API/HyundaiCanadaAPI/HyundaiCanada+StatusParsing.swift
@@ -148,12 +148,15 @@ extension HyundaiCanadaAPIClient {
             return Temperature.Units(unitField)
         }()
 
-        // "HI" / "LOW" string constants flow through unchanged.
+        // HI / LOW map to the HVAC range bounds, which Temperature.maximum/minimum
+        // define in Fahrenheit (62...82). init(value:units:) does NOT convert, so
+        // convert here to the resolved unit — otherwise a Celsius-resolved vehicle
+        // stores an impossible 82°C / 62°C that downstream plausibility checks drop.
         if let raw = rawValue, raw == "HI" {
-            return Temperature(value: Temperature.maximum, units: units)
+            return Temperature(value: Temperature.Units.fahrenheit.convert(Temperature.maximum, to: units), units: units)
         }
         if let raw = rawValue, raw == "LOW" {
-            return Temperature(value: Temperature.minimum, units: units)
+            return Temperature(value: Temperature.Units.fahrenheit.convert(Temperature.minimum, to: units), units: units)
         }
 
         // Hex-code path: "00H", "0EH", etc.


### PR DESCRIPTION
## What this does

`parseCanadaAirTemp` returns the HVAC range bounds for `"HI"`/`"LOW"`:

```swift
if raw == "HI"  { return Temperature(value: Temperature.maximum, units: units) }
if raw == "LOW" { return Temperature(value: Temperature.minimum, units: units) }
```

But `Temperature.maximum`/`minimum` are **Fahrenheit** constants (62/82 — the Fahrenheit `hvacRange`), and `Temperature.init(value:units:)` stores the raw value **without conversion**. When a Canadian response resolves `units` to `.celsius` (top-level `"C"`), `"HI"` lands as **82°C** and `"LOW"` as **62°C** — impossible cabin temperatures. `TemperatureDisplay.isPlausibleForDisplay` then rejects them (Celsius must be ≤ 60), so the reading silently disappears. 62°C is the exact artifact documented for issue #30.

Fix: convert the Fahrenheit bound into the resolved unit before storing — matching what `Temperature`'s string initializer already does (`Units.fahrenheit.convert(Temperature.maximum, to: units)`). A Celsius vehicle now stores ~27.8 °C / 16.7 °C; Fahrenheit is unchanged.

## Testing

`swift test` — **290 tests pass**. The conversion itself is covered by the existing `Temperature.Units.convert` tests; this only changes the unit the HI/LOW bound is stored in. (No Canada-specific parse fixture exists in the suite to assert end-to-end.)

---
*Drafted with AI assistance; verified locally with `swift test`.*
