### PR TITLE
KiaEurope: traverse JSON array indices so legacy (non-CCS2) EV range/SOC parse correctly

### DIFF
--- a/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient+Parsing.swift
+++ b/Sources/BetterBlueKit/API/KiaEurope/KiaEuropeAPIClient+Parsing.swift
@@ -139,8 +139,11 @@ extension KiaEuropeAPIClient {
             targetDC = getDoubleFromJson(from: vehicleState, key: pathMap[.targetDC])
             isCharging = remainChargeTime > 0
         } else {
-            let targetSocList = getChildFromJson(from: vehicleState,
-                                                 key: pathMap[.targetSocList]) as? [[String: Any]] ?? []
+            // targetSocList resolves to an ARRAY leaf; getChildFromJson only returns
+            // dictionaries, so the cast failed and AC/DC targets were always empty.
+            // Read via getAnyFromJson (matches the Hyundai EU sibling).
+            let targetSocList = getAnyFromJson(from: vehicleState,
+                                               key: pathMap[.targetSocList]) as? [[String: Any]] ?? []
             for target in targetSocList {
                 if let plugType = target["plugType"] as? Int,
                    let soc = target["targetSOClevel"] as? Double {
@@ -305,15 +308,29 @@ extension KiaEuropeAPIClient {
     }
 
     private func getAnyFromJson(from data: [String: Any], key keyString: String?) -> Any? {
-        if keyString == nil || keyString!.isEmpty { return nil }
-        var current = data
-        for key in keyString!.split(separator: ".") {
-            if let value = current[String(key)] as? [String: Any] {
-                current = value
+        guard let keyString, !keyString.isEmpty else { return nil }
+
+        var current: Any = data
+
+        for key in keyString.split(separator: ".") {
+            let keyStr = String(key)
+
+            if let dict = current as? [String: Any] {
+                // default dictionary access
+                guard let next = dict[keyStr] else { return nil }
+                current = next
+            } else if let array = current as? [Any] {
+                // array access with index ("drvDistance.0.rangeByFuel") — the legacy
+                // (non-CCS2) Kia EU paths traverse array elements; without this branch
+                // EV range/unit resolved to the whole array and read back as 0.
+                guard let index = Int(keyStr), array.indices.contains(index) else { return nil }
+                current = array[index]
             } else {
-                return current[String(key)]
+                // no dict or array → no further child found
+                return nil
             }
         }
-        return nil
+
+        return current
     }
 }


### PR DESCRIPTION
## What this does

Kia EU's legacy (non-CCS2) parse paths index into JSON arrays, e.g.:

```
vehicleStatus.evStatus.drvDistance.0.rangeByFuel.evModeRange.value
```

But `getAnyFromJson` only descended `[String: Any]` — when traversal reached `drvDistance` (an array) it returned the whole array and never applied the `.0.rangeByFuel…` segments. Net result for **legacy (non-CCS2) Kia EU EVs**: `estimatedRange`/`driveUnit` resolve to `0`. Separately, the legacy `targetSocList` (an array leaf) was read via `getChildFromJson`, which only returns dictionaries, so the `as? [[String: Any]]` cast always failed and **AC/DC charge targets were always empty**.

The Hyundai EU sibling already handles both correctly. This aligns Kia EU with it:
- `getAnyFromJson` gains the array-index branch (`array[index]` for numeric path segments), matching `HyundaiEuropeAPIClient.getAnyFromJson`.
- `targetSocList` is read via `getAnyFromJson` (array leaf), matching the Hyundai EU read.

The file already notes this helper duplication is intentional-but-drift-prone — happy to follow up by lifting these into a shared utility if you'd prefer.

## Testing

`swift test` — **290 tests pass**; the existing CCS2 status test is unaffected (CCS2 uses direct dict keys, not array indices). The traversal change is a verbatim port of the proven Hyundai EU implementation. Note: the suite has no legacy/non-CCS2 Kia EU status fixture to assert the fixed path end-to-end — if you have a sample payload I'm glad to add one.

---
*Drafted with AI assistance; verified locally with `swift test`.*
